### PR TITLE
Define MQTT and sensor configuration separately from implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
 .venv*
-.coverage
+.coverage*
 coverage.xml
 *.egg-info
 *.pyc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Define MQTT and sensor configuration separately from implementation.
   The data logger uses a YAML file now, for example like `etc/mois.yaml`.
 - Added subcommand `make-config`, for creating a configuration blueprint
+- Added subcommand `make-dashboard`, for creating a Grafana Dashboard
 
 ## v0.0.2 - 2024-04-15
 - Publish as `ds18b20-datalogger` package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Tests: Make sensor tests work, using a fake sysfs filesystem
 - Tests: Add basic test case for CLI interface
 - Remove support for Python 3.7
+- Define MQTT and sensor configuration separately from implementation.
+  The data logger uses a YAML file now, for example like `etc/mois.yaml`.
 
 ## v0.0.2 - 2024-04-15
 - Publish as `ds18b20-datalogger` package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   The data logger uses a YAML file now, for example like `etc/mois.yaml`.
 - Added subcommand `make-config`, for creating a configuration blueprint
 - Added subcommand `make-dashboard`, for creating a Grafana Dashboard
+- Added subcommand `read`, for acquiring and displaying a reading on STDOUT
 
 ## v0.0.2 - 2024-04-15
 - Publish as `ds18b20-datalogger` package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Remove support for Python 3.7
 - Define MQTT and sensor configuration separately from implementation.
   The data logger uses a YAML file now, for example like `etc/mois.yaml`.
+- Added subcommand `make-config`, for creating a configuration blueprint
 
 ## v0.0.2 - 2024-04-15
 - Publish as `ds18b20-datalogger` package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include *.md
 recursive-include docs *.md
-recursive-include ds18b20_datalogger *.py *.json
+recursive-include ds18b20_datalogger *.py *.json *.yaml
 prune tests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ https://community.hiveeyes.org/t/laborprotokoll-4x5-temp-matrix-mit-ds18b20/5102
   when acquired through [Kotori DAQ].
 
 
+## Synopsis
+
+```shell
+ds18b20-datalogger run etc/mois.yaml
+```
+
+
 ## Setup
+
 We recommend to install the program into a Python virtualenv.
 ```shell
 python3 -m venv .venv
@@ -69,21 +77,12 @@ https://community.hiveeyes.org/t/ds18b20-temperatur-sensoren-am-one-wire-bus-ano
 ssh youruser@yourpi
 screen
 source /path/to/ds18b20-datalogger/.venv/bin/activate
-ds18b20-datalogger
+wget https://github.com/hiveeyes/ds18b20-datalogger/raw/main/etc/mois.yaml
+ds18b20-datalogger run mois.yaml
 ```
 
 ### MQTT data upload to Hiveeyes
 https://community.hiveeyes.org/t/daten-per-mqtt-und-python-ans-backend-auf-swarm-hiveeyes-org-ubertragen/94/6
-
-### Format your array
-https://community.hiveeyes.org/t/how-to-visualize-2-dimensional-temperature-data-in-grafana/974/9
-```python
-matrix = [[temp_ir_1_1, temp_ir_1_2, temp_ir_1_3, temp_ir_1_4, temp_ir_1_5, temp_ir_1_6],
-          [temp_ir_2_1, temp_ir_2_2, temp_ir_2_3, temp_ir_2_4, temp_ir_2_5, temp_ir_2_6],
-          [temp_ir_3_1, temp_ir_3_2, temp_ir_3_3, temp_ir_3_4, temp_ir_3_5, temp_ir_3_6],
-          [temp_ir_4_1, temp_ir_4_2, temp_ir_4_3, temp_ir_4_4, temp_ir_4_5, temp_ir_4_6],
-          [temp_ir_5_1, temp_ir_5_2, temp_ir_5_3, temp_ir_5_4, temp_ir_5_5, temp_ir_5_6]]
-```
 
 ### Data visualization in Grafana
 https://swarm.hiveeyes.org/grafana/d/Y9PcgE4Sz/mois-ex-wtf-test-ir-sensor-svg-pixmap-copy
@@ -95,6 +94,11 @@ https://community.hiveeyes.org/t/temperatursensoren-justieren-kalibrieren/1744/2
 ```
 */5 * * * * cd /path/to/data-directory && /path/to/ds18b20-datalogger/.venv/bin/ds18b20-datalogger
 ```
+
+## Acknowledgements
+
+Ursprünglicher Code zur Datenverarbeitung auf dem Pi:
+https://community.element14.com/products/raspberry-pi/raspberrypi_projects/b/blog/posts/multiple-ds18b20-temp-sensors-interfacing-with-raspberry-pi?CommentId=9470e4e9-b054-4dd3-9a3f-ac9d1fe38087
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A data logger specializing in reading an array of DS18B20 sensors.
 
 A temperature sensor matrix with heatmap visualization for bee hive monitoring,
-using Raspberry Pi, Python, DS18B20, MQTT, Kotori DAQ, and Grafana. 
+using Raspberry Pi, Linux, Python, DS18B20, MQTT, Kotori DAQ, and Grafana.
 
 
 | View from outside | View from inside (sensor tip details) |
@@ -37,87 +37,113 @@ https://community.hiveeyes.org/t/laborprotokoll-4x5-temp-matrix-mit-ds18b20/5102
 ## What's Inside
 
 - The `ds18b20-datalogger` program, reading DS18B20 sensors and
-  publishing readings to MQTT.
-- JSON representation for a corresponding [Grafana Dashboard],
-  when acquired through [Kotori DAQ].
+  publishing readings to MQTT in JSON format.
+- Configuration file in YAML format, like [`datalogger.yaml`].
+- JSON representation for a corresponding Grafana Dashboard
+  [`grafana-dashboard.json`], when measurement data is submitted
+  and acquired through [Kotori DAQ].
 
 
 ## Synopsis
-
+Acquire single reading, and echo it on STDOUT in JSON format.
 ```shell
-ds18b20-datalogger run etc/mois.yaml
+ds18b20-datalogger read datalogger.yaml
 ```
 
-
-## Setup
-
-We recommend to install the program into a Python virtualenv.
+Take a single reading, and publish it to the configured MQTT topic.
 ```shell
-python3 -m venv .venv
-source .venv/bin/activate
+ds18b20-datalogger run datalogger.yaml
+```
+
+## Live
+In order to see a running system in action, please enjoy inspecting the
+[Live Grafana Dashboard].
+
+
+## Installation
+Install the `ds18b20-datalogger` package from PyPI using `pip`.
+```shell
 pip install --upgrade ds18b20-datalogger
 ```
+See also alternative installation methods and hands-on walkthroughs at
+[development sandbox] and [production setup].
 
-In this spirit, you keep the installation separate from your system Python, so
-you can easily nuke it and start from scratch in case anything goes south.
+## Configuration
+In order to operate the data logger successfully, you will need to configure
+two important details:
 
+- Sensors: Map one-wire sensor sysfs paths to self-assigned sensor names.
+- Telemetry: Adjust MQTT connection settings and MQTT topic.
 
-## Operations
+You can create a blueprint configuration file by using the `make-config`
+subcommand.
+```shell
+ds18b20-datalogger make-config > datalogger.yaml
+```
 
-### Sensor Wiring
+### Appliance: Sensor Wiring and Sensor Mapping
+
 Be aware that you might have to adjust your resistors size.
 With 30 sensors i had erratic sensor mapping using a 4.7k resistor.
 I am getting valid mapping using a 2.2k resistor.
 
-### Sensor Mapping
-https://community.hiveeyes.org/t/ds18b20-temperatur-sensoren-am-one-wire-bus-anordnen/1399
+Please read more about [sensor mapping] on our community forum. In practice,
+just edit the `one-wire` section within the configuration file according to
+your setup.
 
-### Data Publishing
+### Backend: Telemetry and Visualization
+
+The data logger will publish measurements to an MQTT topic, where [Kotori DAQ]
+can pick it up, in order to converge into a timeseries database, and displays
+it on a Grafana Dashboard.
+
+The package includes a corresponding Grafana Dashboard, which can be created
+by invoking the `make-dashboard` subcommand.
+
 ```shell
-ssh youruser@yourpi
-screen
-source /path/to/ds18b20-datalogger/.venv/bin/activate
-wget https://github.com/hiveeyes/ds18b20-datalogger/raw/main/etc/mois.yaml
-ds18b20-datalogger run mois.yaml
+ds18b20-datalogger make-dashboard > dashboard.json
 ```
 
-### MQTT data upload to Hiveeyes
-https://community.hiveeyes.org/t/daten-per-mqtt-und-python-ans-backend-auf-swarm-hiveeyes-org-ubertragen/94/6
+On our community forum, you can find relevant discussions about this topic.
 
-### Data visualization in Grafana
-https://swarm.hiveeyes.org/grafana/d/Y9PcgE4Sz/mois-ex-wtf-test-ir-sensor-svg-pixmap-copy
+- [MQTT data upload to Hiveeyes]
+- [Data visualization in Grafana]
+- [Sensor offsets] (optional)
 
-### Bonus: Sensor offsets
-https://community.hiveeyes.org/t/temperatursensoren-justieren-kalibrieren/1744/2
-
-### Cron Configuration
-```
-*/5 * * * * cd /path/to/data-directory && /path/to/ds18b20-datalogger/.venv/bin/ds18b20-datalogger
-```
 
 ## Acknowledgements
 
-Ursprünglicher Code zur Datenverarbeitung auf dem Pi:
-https://community.element14.com/products/raspberry-pi/raspberrypi_projects/b/blog/posts/multiple-ds18b20-temp-sensors-interfacing-with-raspberry-pi?CommentId=9470e4e9-b054-4dd3-9a3f-ac9d1fe38087
+The original code this implementation has been derived from has been discovered
+on the element14 community forum at [Multiple DS18B20 Temp sensors interfacing
+with Raspberry Pi], shared by [@laluha]. Thanks!
 
 
 ## Contributing
 
 In order to learn how to start hacking on this program, please have a look at the
-documentation about how to install a [development sandbox](./docs/sandbox.md).
+documentation about how to install a [development sandbox].
 
 Contributions of any kind are always welcome and appreciated. Thank you.
 
 
 
-[Grafana Dashboard]: https://swarm.hiveeyes.org/grafana/d/T49wHSaIk/mois-ex-wtf-test-ds18b20-5x6-temp-matrix-svg-pixmap?orgId=2&from=1712771622514&to=1712807415379
+[@laluha]: https://github.com/laluha
+[`datalogger.yaml`]: https://github.com/hiveeyes/ds18b20-datalogger/raw/main/ds18b20_datalogger/datalogger.yaml
+[Data visualization in Grafana]: https://swarm.hiveeyes.org/grafana/d/Y9PcgE4Sz/mois-ex-wtf-test-ir-sensor-svg-pixmap-copy
+[`grafana-dashboard.json`]: https://github.com/hiveeyes/ds18b20-datalogger/raw/main/ds18b20_datalogger/grafana-dashboard.json
 [Kotori DAQ]: https://kotori.readthedocs.io
+[Live Grafana Dashboard]: https://swarm.hiveeyes.org/grafana/d/T49wHSaIk/mois-ex-wtf-test-ds18b20-5x6-temp-matrix-svg-pixmap?orgId=2&from=1712771622514&to=1712807415379
+[MQTT data upload to Hiveeyes]: https://community.hiveeyes.org/t/daten-per-mqtt-und-python-ans-backend-auf-swarm-hiveeyes-org-ubertragen/94/6
+[Multiple DS18B20 Temp sensors interfacing with Raspberry Pi]: https://community.element14.com/products/raspberry-pi/raspberrypi_projects/b/blog/posts/multiple-ds18b20-temp-sensors-interfacing-with-raspberry-pi?CommentId=9470e4e9-b054-4dd3-9a3f-ac9d1fe38087
+[Sensor offsets]: https://community.hiveeyes.org/t/temperatursensoren-justieren-kalibrieren/1744/2
+[sensor mapping]: https://community.hiveeyes.org/t/ds18b20-temperatur-sensoren-am-one-wire-bus-anordnen/1399
 
 [Changelog]: https://github.com/hiveeyes/ds18b20-datalogger/blob/main/CHANGES.md
-[development documentation]: https://ds18b20-datalogger.readthedocs.io/en/latest/sandbox.html
+[development sandbox]: https://github.com/hiveeyes/ds18b20-datalogger/blob/main/docs/sandbox.md
 [Documentation]: https://ds18b20-datalogger.readthedocs.io/
 [Issues]: https://github.com/hiveeyes/ds18b20-datalogger/issues
 [License]: https://github.com/hiveeyes/ds18b20-datalogger/blob/main/LICENSE
+[production setup]: https://github.com/hiveeyes/ds18b20-datalogger/blob/main/docs/production.md
 [PyPI]: https://pypi.org/project/ds18b20-datalogger/
 [Source code]: https://github.com/hiveeyes/ds18b20-datalogger
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,10 +1,17 @@
 # Backlog for ds18b20-datalogger
 
 ## Iteration +1
-- Improve documentation
-- Publish to PyPI
+
+## Iteration +2
+- By default, probe configuration at `/etc/ds18b20-datalogger/config.yaml`
+- Add possibility to connect to MQTT/SSL
 
 ## Done
 - Better software tests
 - Break out sensor mapping configuration from code
   to make it re-usable across different setups
+- Publish to PyPI
+- Subcommand `make-dashboard`
+- Subcommand `read`
+- Test coverage 100%?
+- Improve documentation

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,8 +1,10 @@
 # Backlog for ds18b20-datalogger
 
 ## Iteration +1
+- Improve documentation
+- Publish to PyPI
+
+## Done
 - Better software tests
 - Break out sensor mapping configuration from code
   to make it re-usable across different setups
-- Improve documentation
-- Publish to PyPI

--- a/docs/mois.md
+++ b/docs/mois.md
@@ -1,0 +1,9 @@
+# Measurement reading and publishing for mois
+
+```shell
+ssh youruser@yourpi
+screen
+source /path/to/ds18b20-datalogger/.venv/bin/activate
+wget https://github.com/hiveeyes/ds18b20-datalogger/raw/main/etc/mois.yaml
+ds18b20-datalogger run mois.yaml
+```

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,75 @@
+# Production Setup
+
+A walkthrough how to install the program on a Raspberry Pi machine running
+Linux. In order to learn about more details, please also consult the [README]
+document.
+
+## Installation
+```shell
+sudo su -
+python3 -m venv /opt/ds18b20-datalogger
+/opt/ds18b20-datalogger/bin/pip install ds18b20-datalogger
+/opt/ds18b20-datalogger/bin/ds18b20-datalogger make-config > /etc/ds18b20-datalogger/config.yaml
+/opt/ds18b20-datalogger/bin/ds18b20-datalogger run /etc/ds18b20-datalogger/config.yaml
+```
+
+We recommend to install the program into a Python virtualenv.
+In this spirit, you keep the installation separate from your system Python, so
+you can easily nuke it and start from scratch in case anything goes south.
+
+## Periodic Measurements
+If you want to run the program periodically, for example each five minutes, use
+Cron or, alternatively, Systemd Timers.
+
+### Cron
+This should go into `/etc/cron.d/ds18b20-datalogger`.
+```
+*/5 * * * *  root  /opt/ds18b20-datalogger/bin/ds18b20-datalogger run /etc/ds18b20-datalogger/config.yaml
+```
+
+### Systemd Timers
+
+This should go into `/etc/systemd/system/ds18b20-datalogger.service`.
+```ini
+# Systemd service unit file for ds18b20-datalogger.
+# https://github.com/hiveeyes/ds18b20-datalogger
+
+[Unit]
+Description=DS18B20 data logger
+Wants=ds18b20-datalogger.timer
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ds18b20-datalogger/bin/ds18b20-datalogger run /etc/ds18b20-datalogger/config.yaml
+
+[Install]
+WantedBy=multi-user.target
+```
+
+This should go into `/etc/systemd/system/ds18b20-datalogger.timer`.
+```ini
+# Systemd timer unit file for ds18b20-datalogger.
+# https://github.com/hiveeyes/ds18b20-datalogger
+
+[Unit]
+Description=DS18B20 data logger
+Requires=ds18b20-datalogger.service
+
+[Timer]
+Unit=ds18b20-datalogger.service
+OnCalendar=*-*-* *:0/5
+
+[Install]
+WantedBy=timers.target
+```
+
+Start and enable the service and the timer units.
+```shell
+systemctl start ds18b20-datalogger.service
+systemctl enable ds18b20-datalogger.timer
+systemctl list-timers
+```
+
+
+[README]: https://github.com/hiveeyes/ds18b20-datalogger/blob/main/README.md
+[Systemd Timers]: https://opensource.com/article/20/7/systemd-timers

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,12 +1,20 @@
 # Development Sandbox
 
 ## Install
+Acquire the source code from the repository, install a Python virtualenv,
+and install the package in development mode.
 ```shell
 git clone https://github.com/hiveeyes/ds18b20-datalogger
+cd ds18b20-datalogger
 python3 -m venv .venv
 source .venv/bin/activate
-pip install --editable='.[develop,docs,release,test]'
+pip install --upgrade --editable='.[develop,docs,release,test]'
 ```
+
+We recommend to install the program into a Python virtualenv.
+In this spirit, you keep the installation separate from your system Python, so
+you can easily nuke it and start from scratch in case anything goes south.
+
 
 ## Software tests
 Run all linters, and invoke the test suite.

--- a/ds18b20_datalogger/cli.py
+++ b/ds18b20_datalogger/cli.py
@@ -6,7 +6,7 @@ from ds18b20_datalogger.core import read_ds18b20_sensor_matrix, send_measurement
 from ds18b20_datalogger.model import Settings
 
 if sys.version_info < (3, 9):
-    from importlib_resources import files
+    from importlib_resources import files  # pragma: nocover
 else:
     from importlib.resources import files
 

--- a/ds18b20_datalogger/cli.py
+++ b/ds18b20_datalogger/cli.py
@@ -4,6 +4,11 @@ from pathlib import Path
 from ds18b20_datalogger.core import read_ds18b20_sensor_matrix, send_measurement_mqtt
 from ds18b20_datalogger.model import Settings
 
+if sys.version_info < (3, 9):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
 
 def main():
     if not sys.argv[1:]:
@@ -18,5 +23,8 @@ def main():
         settings = Settings.from_file(configfile)
         reading = read_ds18b20_sensor_matrix(settings.devicemap)
         send_measurement_mqtt(settings.mqtt, reading)
+    elif subcommand == "make-config":
+        config_template = files("ds18b20_datalogger") / "datalogger.yaml"
+        print(config_template.read_text(), file=sys.stdout)  # noqa: T201
     else:
         raise ValueError(f"Subcommand unknown: {subcommand}")

--- a/ds18b20_datalogger/cli.py
+++ b/ds18b20_datalogger/cli.py
@@ -26,5 +26,8 @@ def main():
     elif subcommand == "make-config":
         config_template = files("ds18b20_datalogger") / "datalogger.yaml"
         print(config_template.read_text(), file=sys.stdout)  # noqa: T201
+    elif subcommand == "make-dashboard":
+        dashboard = files("ds18b20_datalogger") / "grafana-dashboard.json"
+        print(dashboard.read_text(), file=sys.stdout)  # noqa: T201
     else:
         raise ValueError(f"Subcommand unknown: {subcommand}")

--- a/ds18b20_datalogger/cli.py
+++ b/ds18b20_datalogger/cli.py
@@ -1,7 +1,22 @@
+import sys
+from pathlib import Path
+
 from ds18b20_datalogger.core import read_ds18b20_sensor_matrix, send_measurement_mqtt
+from ds18b20_datalogger.model import Settings
 
 
 def main():
-    reading = read_ds18b20_sensor_matrix()
-    send_measurement_mqtt(reading)
-    # print(strftime("%Y-%m-%d %H:%M:%S", time.localtime())," Done sending. Going to sleep for 15min.")   # noqa: ERA001
+    if not sys.argv[1:]:
+        raise ValueError("Program needs a subcommand")
+    subcommand = sys.argv[1]
+    if subcommand == "run":
+        if not sys.argv[2:]:
+            raise ValueError("Program needs a configuration file")
+        configfile = Path(sys.argv[2])
+        if not configfile.exists():
+            raise ValueError(f"Configuration file does not exist: {configfile}")
+        settings = Settings.from_file(configfile)
+        reading = read_ds18b20_sensor_matrix(settings.devicemap)
+        send_measurement_mqtt(settings.mqtt, reading)
+    else:
+        raise ValueError(f"Subcommand unknown: {subcommand}")

--- a/ds18b20_datalogger/core.py
+++ b/ds18b20_datalogger/core.py
@@ -11,16 +11,14 @@ screen
 source /path/to/ds18b20-datalogger/.venv/bin/activate
 ds18b20-datalogger
 ```
-
-Ursprünglicher code zur Datenverarbeitung auf dem Pi:
-https://community.element14.com/products/raspberry-pi/raspberrypi_projects/b/blog/posts/multiple-ds18b20-temp-sensors-interfacing-with-raspberry-pi?CommentId=9470e4e9-b054-4dd3-9a3f-ac9d1fe38087
 """  # noqa: E501
 
-import glob
 import json
 import os
 
 import paho.mqtt.client as mqtt
+
+from ds18b20_datalogger.model import DeviceMap, MqttSettings, Reading
 
 
 def read_temp_raw(device_file):
@@ -43,7 +41,10 @@ def read_temp(device_file):
 
 def try_temp(device_file):
     temp_c = -99.0
-    lines = read_temp_raw(device_file + "/w1_slave")
+    try:
+        lines = read_temp_raw(device_file + "/w1_slave")
+    except FileNotFoundError:
+        return None
     if len(lines) == 2:
         if lines[0].strip()[-3:] == "YES":
             equals_pos = lines[1].find("t=")
@@ -52,72 +53,24 @@ def try_temp(device_file):
     return temp_c
 
 
-def send_measurement_mqtt(matrix):
+def send_measurement_mqtt(mqtt_settings: MqttSettings, reading: Reading):
     """
     Publish measurement to MQTT topic in JSON format.
     """
-    # The MQTT host
-    mqtt_host = "swarm.hiveeyes.org"
-    mqtt_port = 1883
-    mqtt_user = "username"
-    mqtt_pass = "some_safe_password"  # noqa: S105
-    # The MQTT topic
-    mqtt_topic = "{realm}/{network}/{gateway}/{node}/data.json".format(
-        # Beekeeper collective
-        realm="hiveeyes",
-        # Beekeeper-ID
-        network="testdrive",
-        # Beehive location
-        gateway="area42",
-        # In my case: Not a hive but the gateway.
-        node="array01",
-    )
-    # Define measurement for 30 sensors in 5x6 matrix
-    measurement = {
-        "temp-ir-1-1": matrix[0][0],
-        "temp-ir-1-2": matrix[0][1],
-        "temp-ir-1-3": matrix[0][2],
-        "temp-ir-1-4": matrix[0][3],
-        "temp-ir-1-5": matrix[0][4],
-        "temp-ir-2-1": matrix[1][0],
-        "temp-ir-2-2": matrix[1][1],
-        "temp-ir-2-3": matrix[1][2],
-        "temp-ir-2-4": matrix[1][3],
-        "temp-ir-2-5": matrix[1][4],
-        "temp-ir-3-1": matrix[2][0],
-        "temp-ir-3-2": matrix[2][1],
-        "temp-ir-3-3": matrix[2][2],
-        "temp-ir-3-4": matrix[2][3],
-        "temp-ir-3-5": matrix[2][4],
-        "temp-ir-4-1": matrix[3][0],
-        "temp-ir-4-2": matrix[3][1],
-        "temp-ir-4-3": matrix[3][2],
-        "temp-ir-4-4": matrix[3][3],
-        "temp-ir-4-5": matrix[3][4],
-        "temp-ir-5-1": matrix[4][0],
-        "temp-ir-5-2": matrix[4][1],
-        "temp-ir-5-3": matrix[4][2],
-        "temp-ir-5-4": matrix[4][3],
-        "temp-ir-5-5": matrix[4][4],
-        "temp-ir-6-1": matrix[5][0],
-        "temp-ir-6-2": matrix[5][1],
-        "temp-ir-6-3": matrix[5][2],
-        "temp-ir-6-4": matrix[5][3],
-        "temp-ir-6-5": matrix[5][4],
-    }
-    # Serialize data as JSON
-    payload = json.dumps(measurement)
-    # Publish to MQTT
+    # Serialize reading to JSON.
+    payload = json.dumps(reading.to_dict())
+    # Publish to MQTT.
     pid = os.getpid()
-    client_id = "{}:{}".format("mois-temp-matrix", str(pid))
+    client_id = "{}:{}".format(mqtt_settings.client_id, str(pid))
     backend = mqtt.Client(client_id=client_id, clean_session=True)
-    backend.username_pw_set(mqtt_user, mqtt_pass)
-    backend.connect(mqtt_host, mqtt_port)
-    backend.publish(mqtt_topic, payload)
+    if mqtt_settings.username and mqtt_settings.password:
+        backend.username_pw_set(mqtt_settings.username, mqtt_settings.password)
+    backend.connect(mqtt_settings.host, mqtt_settings.port or 1883)
+    backend.publish(mqtt_settings.topic, payload)
     backend.disconnect()
 
 
-def read_ds18b20_sensor_matrix():
+def read_ds18b20_sensor_matrix(devicemap: DeviceMap) -> Reading:
     """
     Acquire measurement reading from an array matrix of DS18B20 sensors, connected to a Raspberry Pi machine.
 
@@ -127,125 +80,13 @@ def read_ds18b20_sensor_matrix():
         ls -la /sys/bus/w1/devices/
     """
 
-    temp_ir_1_1 = temp_ir_1_2 = temp_ir_1_3 = temp_ir_1_4 = temp_ir_1_5 = None
-    temp_ir_2_1 = temp_ir_2_2 = temp_ir_2_3 = temp_ir_2_4 = temp_ir_2_5 = None
-    temp_ir_3_1 = temp_ir_3_2 = temp_ir_3_3 = temp_ir_3_4 = temp_ir_3_5 = None
-    temp_ir_4_1 = temp_ir_4_2 = temp_ir_4_3 = temp_ir_4_4 = temp_ir_4_5 = None
-    temp_ir_5_1 = temp_ir_5_2 = temp_ir_5_3 = temp_ir_5_4 = temp_ir_5_5 = None
-    temp_ir_6_1 = temp_ir_6_2 = temp_ir_6_3 = temp_ir_6_4 = temp_ir_6_5 = None
-
-    # Mount the device.
+    # Install drivers, in order to provide sysfs-based
+    # access to devices connected to the one-wire bus.
     os.system("modprobe w1-gpio")  # noqa: S605, S607
     os.system("modprobe w1-therm")  # noqa: S605, S607
 
-    # Get all the filenames begin with 28 in the path base_dir.
-    base_dir = "/sys/bus/w1/devices/"
-    device_folders = glob.glob(base_dir + "28*")
-
-    # print device_folders  # DEBUG
-
-    for folder in device_folders:
-        tc = read_temp(folder)
-        label = "no_known_label"
-        if folder == "/sys/bus/w1/devices/28-0346d4430b06":
-            label = "temp-ir-1-1"
-            temp_ir_1_1 = tc
-        if folder == "/sys/bus/w1/devices/28-0cf3d443ba40":
-            label = "temp-ir-1-2"
-            temp_ir_1_2 = tc
-        if folder == "/sys/bus/w1/devices/28-0e49d44343bd":
-            label = "temp-ir-1-3"
-            temp_ir_1_3 = tc
-        if folder == "/sys/bus/w1/devices/28-11c1d443f241":
-            label = "temp-ir-1-4"
-            temp_ir_1_4 = tc
-        if folder == "/sys/bus/w1/devices/28-1937d443bed6":
-            label = "temp-ir-1-5"
-            temp_ir_1_5 = tc
-        if folder == "/sys/bus/w1/devices/28-2231d443d266":
-            label = "temp-ir-2-1"
-            temp_ir_2_1 = tc
-        if folder == "/sys/bus/w1/devices/28-282bd4430f5e":
-            label = "temp-ir-2-2"
-            temp_ir_2_2 = tc
-        if folder == "/sys/bus/w1/devices/28-2846d443e4f2":
-            label = "temp-ir-2-3"
-            temp_ir_2_3 = tc
-        if folder == "/sys/bus/w1/devices/28-297ad443f622":
-            label = "temp-ir-2-4"
-            temp_ir_2_4 = tc
-        if folder == "/sys/bus/w1/devices/28-2c6cd443ccf7":
-            label = "temp-ir-2-5"
-            temp_ir_2_5 = tc
-        if folder == "/sys/bus/w1/devices/28-304ad4436d1a":
-            label = "temp-ir-3-1"
-            temp_ir_3_1 = tc
-        if folder == "/sys/bus/w1/devices/28-32c9d443b51b":
-            label = "temp-ir-3-2"
-            temp_ir_3_2 = tc
-        if folder == "/sys/bus/w1/devices/28-3ce1d443d148":
-            label = "temp-ir-3-3"
-            temp_ir_3_3 = tc
-        if folder == "/sys/bus/w1/devices/28-400bd4439156":
-            label = "temp-ir-3-4"
-            temp_ir_3_4 = tc
-        if folder == "/sys/bus/w1/devices/28-450ed4430afe":
-            label = "temp-ir-3-5"
-            temp_ir_3_5 = tc
-        if folder == "/sys/bus/w1/devices/28-4694d44325ca":
-            label = "temp-ir-4-1"
-            temp_ir_4_1 = tc
-        if folder == "/sys/bus/w1/devices/28-5196d4434d53":
-            label = "temp-ir-4-2"
-            temp_ir_4_2 = tc
-        if folder == "/sys/bus/w1/devices/28-550cd4434596":
-            label = "temp-ir-4-3"
-            temp_ir_4_3 = tc
-        if folder == "/sys/bus/w1/devices/28-57b6d44367cb":
-            label = "temp-ir-4-4"
-            temp_ir_4_4 = tc
-        if folder == "/sys/bus/w1/devices/28-5821d44339c2":
-            label = "temp-ir-4-5"
-            temp_ir_4_5 = tc
-        if folder == "/sys/bus/w1/devices/28-65f2d4434f51":
-            label = "temp-ir-5-1"
-            temp_ir_5_1 = tc
-        if folder == "/sys/bus/w1/devices/28-6723d443b9ea":
-            label = "temp-ir-5-2"
-            temp_ir_5_2 = tc
-        if folder == "/sys/bus/w1/devices/28-6755d443de81":
-            label = "temp-ir-5-3"
-            temp_ir_5_3 = tc
-        if folder == "/sys/bus/w1/devices/28-6950d443323f":
-            label = "temp-ir-5-4"
-            temp_ir_5_4 = tc
-        if folder == "/sys/bus/w1/devices/28-6ae6d4434899":
-            label = "temp-ir-5-5"
-            temp_ir_5_5 = tc
-        if folder == "/sys/bus/w1/devices/28-6b2ad4437e19":
-            label = "temp-ir-6-1"
-            temp_ir_6_1 = tc
-        if folder == "/sys/bus/w1/devices/28-6f8ad443a557":
-            label = "temp-ir-6-2"
-            temp_ir_6_2 = tc
-        if folder == "/sys/bus/w1/devices/28-72d1d44362f0":
-            label = "temp-ir-6-3"
-            temp_ir_6_3 = tc
-        if folder == "/sys/bus/w1/devices/28-72d8d44397f7":
-            label = "temp-ir-6-4"
-            temp_ir_6_4 = tc
-        if folder == "/sys/bus/w1/devices/28-79d2d4430cf1":
-            label = "temp-ir-6-5"  # noqa: F841
-            temp_ir_6_5 = tc
-    #    print ('%s %3.1f deg C %s' % (folder, tc, label))  # noqa: ERA001
-    #    print ('%s %3.1f' % (label, tc))                   # noqa: ERA001
-    matrix = [
-        [temp_ir_1_1, temp_ir_1_2, temp_ir_1_3, temp_ir_1_4, temp_ir_1_5],
-        [temp_ir_2_1, temp_ir_2_2, temp_ir_2_3, temp_ir_2_4, temp_ir_2_5],
-        [temp_ir_3_1, temp_ir_3_2, temp_ir_3_3, temp_ir_3_4, temp_ir_3_5],
-        [temp_ir_4_1, temp_ir_4_2, temp_ir_4_3, temp_ir_4_4, temp_ir_4_5],
-        [temp_ir_5_1, temp_ir_5_2, temp_ir_5_3, temp_ir_5_4, temp_ir_5_5],
-        [temp_ir_6_1, temp_ir_6_2, temp_ir_6_3, temp_ir_6_4, temp_ir_6_5],
-    ]
-    #  print (matrix)                                       # noqa: ERA001
-    return matrix
+    reading = Reading()
+    for device in devicemap.devices:
+        value = read_temp(device.path)
+        reading.add_measurement(name=device.name, value=value)
+    return reading

--- a/ds18b20_datalogger/core.py
+++ b/ds18b20_datalogger/core.py
@@ -1,18 +1,3 @@
-#!/usr/bin/env python
-"""
-Configure:
-- Insert your own sensor addresses (read_ds18b20_sensor_matrix).
-- Adjust MQTT connection settings and credentials (send_measurement_mqtt).
-
-Start:
-```
-ssh to your pi
-screen
-source /path/to/ds18b20-datalogger/.venv/bin/activate
-ds18b20-datalogger
-```
-"""  # noqa: E501
-
 import json
 import os
 

--- a/ds18b20_datalogger/datalogger.yaml
+++ b/ds18b20_datalogger/datalogger.yaml
@@ -1,0 +1,31 @@
+# Configuration file for ds18b20-datalogger
+# https://github.com/hiveeyes/ds18b20-datalogger
+
+mqtt:
+
+  # MQTT broker connection.
+  client_id: "ds18b20-datalogger"
+  host: "mqtt.example.org"
+  port: 1883
+  username: "username"
+  password: "password"
+
+  # MQTT topic in SensorWAN 3.0 format.
+  # https://hiveeyes.org/docs/arduino/SensorWAN.html
+  #
+  # Format: {realm}/{network}/{group}/{name}/data.json
+  topic: "organization/beekeeper/apiary/hive/data.json"
+
+one-wire:
+  - name: temp-ir-1-1
+    path: /sys/bus/w1/devices/28-0346d4430b06
+  - name: temp-ir-1-2
+    path: /sys/bus/w1/devices/28-0cf3d443ba40
+  - name: temp-ir-1-3
+    path: /sys/bus/w1/devices/28-0e49d44343bd
+  - name: temp-ir-2-1
+    path: /sys/bus/w1/devices/28-2231d443d266
+  - name: temp-ir-2-2
+    path: /sys/bus/w1/devices/28-282bd4430f5e
+  - name: temp-ir-2-3
+    path: /sys/bus/w1/devices/28-2846d443e4f2

--- a/ds18b20_datalogger/model.py
+++ b/ds18b20_datalogger/model.py
@@ -1,0 +1,109 @@
+import dataclasses
+import typing as t
+from collections import OrderedDict
+from pathlib import Path
+
+import yaml
+
+from ds18b20_datalogger.util import partition
+
+
+@dataclasses.dataclass
+class Device:
+    """
+    Manage a one-wire device, mapping a sysfs path to a user-assigned name/label.
+    """
+
+    name: str
+    path: Path
+
+
+class DeviceMap:
+    """
+    Manage a map of one-wire devices to names/labels.
+    """
+
+    def __init__(self):
+        self.devices: t.List[Device] = []
+
+    def by_name(self, name: str) -> Device:
+        for device in self.devices:
+            if device.name == name:
+                return device
+        raise KeyError(f"Device not found: name={name}")
+
+    def by_fullpath(self, path: Path) -> Device:
+        for device in self.devices:
+            if device.path == path:
+                return device
+        raise KeyError(f"Device not found: path={path}")
+
+    def by_pathname(self, path: Path) -> Device:
+        for device in self.devices:
+            if device.path.name == path.name:
+                return device
+        raise KeyError(f"Device not found: pathname={path.name}")
+
+
+@dataclasses.dataclass
+class MqttSettings:
+    """
+    Container for MQTT settings.
+    """
+
+    host: str
+    topic: str
+    port: t.Optional[int] = None
+    username: t.Optional[str] = None
+    password: t.Optional[str] = None
+    client_id: t.Optional[str] = None
+
+
+@dataclasses.dataclass
+class Settings:
+    """
+    General settings container.
+    """
+
+    mqtt: MqttSettings
+    devicemap: DeviceMap
+
+    @classmethod
+    def from_file(cls, configfile: Path):
+        data = yaml.safe_load(configfile.read_text())
+        devicemap = DeviceMap()
+        for item in data["one-wire"]:
+            devicemap.devices.append(Device(**item))
+        return cls(mqtt=MqttSettings(**data["mqtt"]), devicemap=devicemap)
+
+
+@dataclasses.dataclass
+class Measurement:
+    """
+    Manage a measurement, coming from a device.
+    """
+
+    name: str
+    value: float
+
+
+@dataclasses.dataclass
+class Reading:
+    """
+    Manage a reading, made of multiple measurements.
+    """
+
+    measurements: t.List[Measurement] = dataclasses.field(default_factory=list)
+
+    def add_measurement(self, name: str, value: float):
+        self.measurements.append(Measurement(name=name, value=value))
+
+    def to_dict(self) -> t.Dict[str, float]:
+        data = OrderedDict()
+        for measurement in self.measurements:
+            data[measurement.name] = measurement.value
+        return data
+
+    def to_matrix(self, rowlength: int):
+        values = [m.value for m in self.measurements]
+        return list(partition(values, rowlength))

--- a/ds18b20_datalogger/model.py
+++ b/ds18b20_datalogger/model.py
@@ -15,7 +15,7 @@ class Device:
     """
 
     name: str
-    path: Path
+    path: str
 
 
 class DeviceMap:
@@ -34,15 +34,16 @@ class DeviceMap:
 
     def by_fullpath(self, path: Path) -> Device:
         for device in self.devices:
-            if device.path == path:
+            if str(device.path) == str(path):
                 return device
         raise KeyError(f"Device not found: path={path}")
 
     def by_pathname(self, path: Path) -> Device:
+        needle = Path(path).name
         for device in self.devices:
-            if device.path.name == path.name:
+            if Path(device.path).name == needle:
                 return device
-        raise KeyError(f"Device not found: pathname={path.name}")
+        raise KeyError(f"Device not found: pathname={needle}")
 
 
 @dataclasses.dataclass

--- a/ds18b20_datalogger/util.py
+++ b/ds18b20_datalogger/util.py
@@ -1,0 +1,13 @@
+import itertools
+from typing import Any, Generator, List
+
+
+def partition(lst, chunksize: int) -> Generator[List[Any], None, None]:
+    """
+    Partition a list into equal sized chunks.
+
+    Split a List into Chunks of Given Size in Python
+    https://favtutor.com/blogs/partition-list-python
+    """
+    for i in range(0, len(lst), chunksize):
+        yield list(itertools.islice(lst, i, i + chunksize))

--- a/etc/mois.yaml
+++ b/etc/mois.yaml
@@ -1,0 +1,78 @@
+mqtt:
+
+  # MQTT broker connection.
+  client_id: "mois-temp-matrix"
+  host: "swarm.hiveeyes.org"
+  port: 1883
+  username: "username"
+  password: "password"
+
+  # MQTT topic.
+  # {realm}/{network}/{gateway}/{node}/data.json
+  # realm: Beekeeper collective
+  # network: Beekeeper-ID
+  # gateway: Hive location
+  # node: Hive name
+  topic: "hiveeyes/testdrive/area-42/array-one/data.json"
+
+one-wire:
+  - name: temp-ir-1-1
+    path: /sys/bus/w1/devices/28-0346d4430b06
+  - name: temp-ir-1-2
+    path: /sys/bus/w1/devices/28-0cf3d443ba40
+  - name: temp-ir-1-3
+    path: /sys/bus/w1/devices/28-0e49d44343bd
+  - name: temp-ir-1-4
+    path: /sys/bus/w1/devices/28-11c1d443f241
+  - name: temp-ir-1-5
+    path: /sys/bus/w1/devices/28-1937d443bed6
+  - name: temp-ir-2-1
+    path: /sys/bus/w1/devices/28-2231d443d266
+  - name: temp-ir-2-2
+    path: /sys/bus/w1/devices/28-282bd4430f5e
+  - name: temp-ir-2-3
+    path: /sys/bus/w1/devices/28-2846d443e4f2
+  - name: temp-ir-2-4
+    path: /sys/bus/w1/devices/28-297ad443f622
+  - name: temp-ir-2-5
+    path: /sys/bus/w1/devices/28-2c6cd443ccf7
+  - name: temp-ir-3-1
+    path: /sys/bus/w1/devices/28-304ad4436d1a
+  - name: temp-ir-3-2
+    path: /sys/bus/w1/devices/28-32c9d443b51b
+  - name: temp-ir-3-3
+    path: /sys/bus/w1/devices/28-3ce1d443d148
+  - name: temp-ir-3-4
+    path: /sys/bus/w1/devices/28-400bd4439156
+  - name: temp-ir-3-5
+    path: /sys/bus/w1/devices/28-450ed4430afe
+  - name: temp-ir-4-1
+    path: /sys/bus/w1/devices/28-4694d44325ca
+  - name: temp-ir-4-2
+    path: /sys/bus/w1/devices/28-5196d4434d53
+  - name: temp-ir-4-3
+    path: /sys/bus/w1/devices/28-550cd4434596
+  - name: temp-ir-4-4
+    path: /sys/bus/w1/devices/28-57b6d44367cb
+  - name: temp-ir-4-5
+    path: /sys/bus/w1/devices/28-5821d44339c2
+  - name: temp-ir-5-1
+    path: /sys/bus/w1/devices/28-65f2d4434f51
+  - name: temp-ir-5-2
+    path: /sys/bus/w1/devices/28-6723d443b9ea
+  - name: temp-ir-5-3
+    path: /sys/bus/w1/devices/28-6755d443de81
+  - name: temp-ir-5-4
+    path: /sys/bus/w1/devices/28-6950d443323f
+  - name: temp-ir-5-5
+    path: /sys/bus/w1/devices/28-6ae6d4434899
+  - name: temp-ir-6-1
+    path: /sys/bus/w1/devices/28-6b2ad4437e19
+  - name: temp-ir-6-2
+    path: /sys/bus/w1/devices/28-6f8ad443a557
+  - name: temp-ir-6-3
+    path: /sys/bus/w1/devices/28-72d1d44362f0
+  - name: temp-ir-6-4
+    path: /sys/bus/w1/devices/28-72d8d44397f7
+  - name: temp-ir-6-5
+    path: /sys/bus/w1/devices/28-79d2d4430cf1

--- a/etc/mois.yaml
+++ b/etc/mois.yaml
@@ -1,3 +1,6 @@
+# Configuration file for ds18b20-datalogger
+# https://github.com/hiveeyes/ds18b20-datalogger
+
 mqtt:
 
   # MQTT broker connection.
@@ -8,11 +11,13 @@ mqtt:
   password: "password"
 
   # MQTT topic.
-  # {realm}/{network}/{gateway}/{node}/data.json
-  # realm: Beekeeper collective
-  # network: Beekeeper-ID
-  # gateway: Hive location
-  # node: Hive name
+  # Structure: {realm}/{network}/{gateway}/{node}/data.json
+  #
+  # Details:
+  # :realm:   Beekeeper collective / group
+  # :network: Beekeeper identifier
+  # :gateway: Hive location
+  # :node:    Hive name
   topic: "hiveeyes/testdrive/area-42/array-one/data.json"
 
 one-wire:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: GNU General Public License (GPL)",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import typing as t
 
@@ -28,3 +29,11 @@ def test_cli_make_config():
     config = yaml.safe_load(output)
     assert "mqtt" in config
     assert "one-wire" in config
+
+
+def test_cli_make_dashboard():
+    exitcode, output = invoke("ds18b20-datalogger make-dashboard")
+    dashboard = json.loads(output)
+    assert "annotations" in dashboard
+    assert "panels" in dashboard
+    assert "title" in dashboard

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,11 @@ def test_cli_run_read_no_config():
     assert "Program needs a configuration file" in output
 
 
+def test_cli_run_read_nonexist_config():
+    exitcode, output = invoke("ds18b20-datalogger run foo.yaml")
+    assert "Configuration file does not exist: foo.yaml" in output
+
+
 def test_cli_read_success():
     command = shlex.split("ds18b20-datalogger read ds18b20_datalogger/datalogger.yaml")
     process = subprocess.run(command, stdout=subprocess.PIPE)  # noqa: S603
@@ -40,7 +45,7 @@ def test_cli_read_success():
 def test_cli_run_almost_success():
     exitcode, output = invoke("ds18b20-datalogger run ds18b20_datalogger/datalogger.yaml")
     assert exitcode == 1
-    assert "nodename nor servname provided, or not known" in output
+    assert "nodename nor servname provided, or not known" in output or "Name or service not known" in output
 
 
 def test_cli_make_config():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,20 @@
-import shlex
 import subprocess
+import typing as t
 
 
-def test_cli():
-    command = "ds18b20-datalogger"
-    subprocess.check_call(shlex.split(command))  # noqa: S603, S605
+def invoke(command: str) -> t.Tuple[int, str]:
+    return subprocess.getstatusoutput(command)  # noqa: S603, S605
+
+
+def test_cli_run():
+    invoke("ds18b20-datalogger run")
+
+
+def test_cli_no_subcommand():
+    exitcode, output = invoke("ds18b20-datalogger")
+    assert "Program needs a subcommand" in output
+
+
+def test_cli_unknown_subcommand():
+    exitcode, output = invoke("ds18b20-datalogger foo")
+    assert "Subcommand unknown: foo" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,11 @@
 import subprocess
 import typing as t
 
+import yaml
+
 
 def invoke(command: str) -> t.Tuple[int, str]:
     return subprocess.getstatusoutput(command)  # noqa: S603, S605
-
-
-def test_cli_run():
-    invoke("ds18b20-datalogger run")
 
 
 def test_cli_no_subcommand():
@@ -18,3 +16,15 @@ def test_cli_no_subcommand():
 def test_cli_unknown_subcommand():
     exitcode, output = invoke("ds18b20-datalogger foo")
     assert "Subcommand unknown: foo" in output
+
+
+def test_cli_run_no_config():
+    exitcode, output = invoke("ds18b20-datalogger run")
+    assert "Program needs a configuration file" in output
+
+
+def test_cli_make_config():
+    exitcode, output = invoke("ds18b20-datalogger make-config")
+    config = yaml.safe_load(output)
+    assert "mqtt" in config
+    assert "one-wire" in config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import subprocess
 import typing as t
 
@@ -19,9 +20,27 @@ def test_cli_unknown_subcommand():
     assert "Subcommand unknown: foo" in output
 
 
-def test_cli_run_no_config():
+def test_cli_run_read_no_config():
     exitcode, output = invoke("ds18b20-datalogger run")
     assert "Program needs a configuration file" in output
+
+    exitcode, output = invoke("ds18b20-datalogger read")
+    assert "Program needs a configuration file" in output
+
+
+def test_cli_read_success():
+    command = shlex.split("ds18b20-datalogger read ds18b20_datalogger/datalogger.yaml")
+    process = subprocess.run(command, stdout=subprocess.PIPE)  # noqa: S603
+    reading = json.loads(process.stdout)
+    assert "temp-ir-1-1" in reading
+    assert "temp-ir-2-3" in reading
+    assert len(reading) == 6
+
+
+def test_cli_run_almost_success():
+    exitcode, output = invoke("ds18b20-datalogger run ds18b20_datalogger/datalogger.yaml")
+    assert exitcode == 1
+    assert "nodename nor servname provided, or not known" in output
 
 
 def test_cli_make_config():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from ds18b20_datalogger.model import Device, Settings
+
+
+@pytest.fixture
+def settings() -> Settings:
+    configfile = Path("etc") / "mois.yaml"
+    return Settings.from_file(configfile)
+
+
+def test_model_devicemap_by_name_success(settings):
+    assert settings.devicemap.by_name("temp-ir-1-1") == Device(
+        name="temp-ir-1-1", path="/sys/bus/w1/devices/28-0346d4430b06"
+    )
+
+
+def test_model_devicemap_by_name_failure(settings):
+    with pytest.raises(KeyError) as ex:
+        settings.devicemap.by_name("foo")
+    assert ex.match("'Device not found: name=foo'")
+
+
+def test_model_devicemap_by_fullpath_success(settings):
+    assert settings.devicemap.by_fullpath("/sys/bus/w1/devices/28-0346d4430b06") == Device(
+        name="temp-ir-1-1", path="/sys/bus/w1/devices/28-0346d4430b06"
+    )
+
+
+def test_model_devicemap_by_fullpath_failure(settings):
+    with pytest.raises(KeyError) as ex:
+        settings.devicemap.by_fullpath("foo")
+    assert ex.match("'Device not found: path=foo'")
+
+
+def test_model_devicemap_by_pathname_success(settings):
+    assert settings.devicemap.by_pathname("28-0346d4430b06") == Device(
+        name="temp-ir-1-1", path="/sys/bus/w1/devices/28-0346d4430b06"
+    )
+
+
+def test_model_devicemap_by_pathname_failure(settings):
+    with pytest.raises(KeyError) as ex:
+        settings.devicemap.by_pathname("foo")
+    assert ex.match("'Device not found: pathname=foo'")


### PR DESCRIPTION
## About
The data logger uses a YAML file for configuration now, for example like `etc/mois.yaml`. You will then invoke it like:
```shell
pip install ds18b20-datalogger
wget https://github.com/hiveeyes/ds18b20-datalogger/raw/main/etc/mois.yaml
ds18b20-datalogger run mois.yaml
```

## More
- Add subcommand `make-config`, for creating a configuration blueprint
- Add subcommand `make-dashboard`, for creating a Grafana Dashboard
- Add subcommand `read`, for acquiring and displaying a reading on STDOUT
- Tests: Bring code coverage back to 100%
- Improve documentation
